### PR TITLE
Create/message delete

### DIFF
--- a/frontend/components/chat/ChatMessages.js
+++ b/frontend/components/chat/ChatMessages.js
@@ -267,6 +267,7 @@ const ChatMessages = ({
   onLoadMore = () => {},
   onReactionAdd = () => {},
   onReactionRemove = () => {},
+  onMessageDelete = () => {},
   messagesEndRef,
   socketRef,
   scrollToBottomOnNewMessage = true,
@@ -398,6 +399,32 @@ const ChatMessages = ({
     });
   }, [messages, streamingMessages]);
 
+  // 메시지 삭제 핸들러
+  const handleMessageDelete = useCallback(async (messageId) => {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/messages/${messageId}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-auth-token': JSON.parse(localStorage.getItem('user'))?.token,
+          'x-session-id': JSON.parse(localStorage.getItem('user'))?.sessionId
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error('메시지 삭제에 실패했습니다.');
+      }
+
+      // 상위 컴포넌트에 삭제 완료 알림
+      if (onMessageDelete) {
+        onMessageDelete(messageId);
+      }
+    } catch (error) {
+      console.error('Message delete error:', error);
+      throw error;
+    }
+  }, [onMessageDelete]);
+
   const renderMessage = useCallback((msg, idx) => {
     if (!msg || !SystemMessage || !FileMessage || !UserMessage || !AIMessage) {
       console.error('Message component undefined:', {
@@ -415,7 +442,8 @@ const ChatMessages = ({
       currentUser,
       room,
       onReactionAdd,
-      onReactionRemove
+      onReactionRemove,
+      onMessageDelete: handleMessageDelete
     };
 
     console.log("✅msg.type:",msg.type);
@@ -434,7 +462,6 @@ const ChatMessages = ({
     return (
       <MessageComponent
         key={msg._id || `msg-${idx}`}
-        ref={isLast ? lastMessageRef : null}
         {...commonProps}
         msg={msg}
         content={msg.content}
@@ -444,7 +471,7 @@ const ChatMessages = ({
         socketRef={socketRef}
       />
     );
-  }, [allMessages.length, currentUser, room, isMine, onReactionAdd, onReactionRemove, socketRef]);
+  }, [allMessages.length, currentUser, room, isMine, onReactionAdd, onReactionRemove, handleMessageDelete, socketRef]);
 
   return (
     <div 

--- a/frontend/components/chat/ChatMessages.js
+++ b/frontend/components/chat/ChatMessages.js
@@ -415,10 +415,10 @@ const ChatMessages = ({
         throw new Error('메시지 삭제에 실패했습니다.');
       }
 
-      // 상위 컴포넌트에 삭제 완료 알림
-      if (onMessageDelete) {
-        onMessageDelete(messageId);
-      }
+      const responseData = await response.json();
+
+      // API 응답 데이터 반환
+      return responseData;
     } catch (error) {
       console.error('Message delete error:', error);
       throw error;

--- a/frontend/components/chat/Message/FileMessage.js
+++ b/frontend/components/chat/Message/FileMessage.js
@@ -397,6 +397,7 @@ const FileMessage = ({
           onMessageDelete={onMessageDelete}
           isMine={isMine}
           room={room}
+          messageRef={msg}
         />        
       </div>
     </div>

--- a/frontend/components/chat/Message/FileMessage.js
+++ b/frontend/components/chat/Message/FileMessage.js
@@ -24,6 +24,7 @@ const FileMessage = ({
   currentUser = null,
   onReactionAdd,
   onReactionRemove,
+  onMessageDelete,
   room = null,
   messageRef,
   socketRef
@@ -393,6 +394,7 @@ const FileMessage = ({
           currentUserId={currentUser?.id}
           onReactionAdd={onReactionAdd}
           onReactionRemove={onReactionRemove}
+          onMessageDelete={onMessageDelete}
           isMine={isMine}
           room={room}
         />        
@@ -411,7 +413,8 @@ FileMessage.defaultProps = {
     }
   },
   isMine: false,
-  currentUser: null
+  currentUser: null,
+  onMessageDelete: () => {}
 };
 
 export default React.memo(FileMessage);

--- a/frontend/components/chat/Message/UserMessage.js
+++ b/frontend/components/chat/Message/UserMessage.js
@@ -81,20 +81,21 @@ const UserMessage = ({
           onMessageDelete={onMessageDelete}
           isMine={isMine}
           room={room}
+          messageRef={msg}
         />
       </div>
     </div>
   );
-  };
-  
-  UserMessage.defaultProps = {
-    msg: {},
-    isMine: false,
-    currentUser: null,
-    onReactionAdd: () => {},
-    onReactionRemove: () => {},
+};
+
+UserMessage.defaultProps = {
+  msg: {},
+  isMine: false,
+  currentUser: null,
+  onReactionAdd: () => {},
+  onReactionRemove: () => {},
     onMessageDelete: () => {},
-    room: null
-  };
-  
-  export default React.memo(UserMessage);
+  room: null
+};
+
+export default React.memo(UserMessage);

--- a/frontend/components/chat/Message/UserMessage.js
+++ b/frontend/components/chat/Message/UserMessage.js
@@ -6,12 +6,13 @@ import ReadStatus from '../ReadStatus';
 import { generateColorFromEmail, getContrastTextColor } from '../../../utils/colorUtils';
 
 const UserMessage = ({
-  msg = {}, 
-  isMine = false, 
-  currentUser = null,
+  msg, 
+  isMine, 
+  currentUser,
   onReactionAdd,
   onReactionRemove,
-  room = null,
+  onMessageDelete,
+  room,
   messageRef,
   socketRef
 }) => {
@@ -77,21 +78,23 @@ const UserMessage = ({
           currentUserId={currentUser?.id}
           onReactionAdd={onReactionAdd}
           onReactionRemove={onReactionRemove}
+          onMessageDelete={onMessageDelete}
           isMine={isMine}
           room={room}
         />
       </div>
     </div>
   );
-};
-
-UserMessage.defaultProps = {
-  msg: {},
-  isMine: false,
-  currentUser: null,
-  onReactionAdd: () => {},
-  onReactionRemove: () => {},
-  room: null
-};
-
-export default React.memo(UserMessage);
+  };
+  
+  UserMessage.defaultProps = {
+    msg: {},
+    isMine: false,
+    currentUser: null,
+    onReactionAdd: () => {},
+    onReactionRemove: () => {},
+    onMessageDelete: () => {},
+    room: null
+  };
+  
+  export default React.memo(UserMessage);

--- a/frontend/pages/chat.js
+++ b/frontend/pages/chat.js
@@ -47,6 +47,7 @@ const ChatPage = () => {
     error,
     handleReactionAdd,
     handleReactionRemove,
+    handleMessageDelete,
     loadingMessages,
     hasMoreMessages,
     handleLoadMore
@@ -200,6 +201,7 @@ const ChatPage = () => {
         messagesEndRef={messagesEndRef}
         onReactionAdd={handleReactionAdd}
         onReactionRemove={handleReactionRemove}
+        onMessageDelete={handleMessageDelete}
         loadingMessages={loadingMessages}
         hasMoreMessages={hasMoreMessages}
         onLoadMore={handleLoadMore}

--- a/frontend/pages/register.js
+++ b/frontend/pages/register.js
@@ -132,10 +132,18 @@ const Register = () => {
     } catch (err) {
       console.error('Registration error:', err);
       
-      if (err.response?.data?.errors) {
+      // 409 에러 (이미 존재하는 이메일)인 경우 특별 처리
+      if (err.response?.status === 409) {
+        setErrors([{ 
+          field: 'email',
+          message: err.response.data?.message || '이미 가입된 이메일입니다.'
+        }]);
+      } else if (err.response?.data?.errors) {
         setErrors(err.response.data.errors);
       } else if (err.response?.data?.message) {
         setErrors([{ message: err.response.data.message }]);
+      } else if (err.message) {
+        setErrors([{ message: err.message }]);
       } else {
         setErrors([{ message: '회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.' }]);
       }


### PR DESCRIPTION
## 메세지 삭제 기능 추가

### 변경사항 요약:
1.  MessageActions.js - 핵심 삭제 기능
  - TrashIcon import 추가
  - onMessageDelete prop 추가
  - isDeleting state 추가 (로딩 상태)
  - handleDelete 함수 구현:
    - 본인 메시지만 삭제 가능
    - 확인 창 (confirm)
    - API 호출 및 에러 처리
    - Toast 메시지
  -  휴지통 버튼 UI. 추가 (본인 메시지에만 표시)
2. UserMessage.js - Props 전달
  - onMessageDelete prop 받아서 MessageActions로 전달
  - defaultProps에 onMessageDelete 추가
3. FileMessage.js - 파일 메시지도 삭제 지원
  - onMessageDelete prop 받아서 MessageActions로 전달
  - defaultProps에 onMessageDelete 추가
4. useChatRoom.js - 삭제 로직 핵심
  - handleMessageDelete 함수 구현
  - messageDeleted 소켓 이벤트 리스너 추가
  - 삭제된 메시지를 messages 배열에서 제거
  - processedMessageIds에서도 제거
5.  chat.js - 최상위 연결
  - handleMessageDelete를 ChatMessages로 전달